### PR TITLE
fix: Fix `ForbidJavaFilesTask` configuration failure when registered in non-android module with android module parent

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed 
+- Fix `ForbidJavaFilesTask` configuration failure when registered in non-android module with android module parent
 
 ## [0.12.0] - 2020-05-16
 ## Added

--- a/plugins/src/main/kotlin/com/project/starter/modules/internal/AndroidPluginUtils.kt
+++ b/plugins/src/main/kotlin/com/project/starter/modules/internal/AndroidPluginUtils.kt
@@ -1,6 +1,7 @@
 package com.project.starter.modules.internal
 
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.project.starter.config.extensions.RootConfigExtension
@@ -58,7 +59,14 @@ internal fun Project.configureAndroidProject(variants: DomainObjectSet<out BaseV
     }
     val javaFilesAllowed = projectConfig.javaFilesAllowed ?: rootConfig.javaFilesAllowed
     if (!javaFilesAllowed) {
-        tasks.named("preBuild").dependsOn(registerForbidJavaFilesTask())
+        val forbidJavaFiles = registerForbidJavaFilesTask { task ->
+            val extension = project.extensions.getByType(TestedExtension::class.java)
+            extension.sourceSets.configureEach { sourceSet ->
+                task.source += sourceSet.java.sourceFiles
+            }
+        }
+
+        tasks.named("preBuild").dependsOn(forbidJavaFiles)
     }
 }
 

--- a/plugins/src/main/kotlin/com/project/starter/modules/tasks/ForbidJavaFilesTask.kt
+++ b/plugins/src/main/kotlin/com/project/starter/modules/tasks/ForbidJavaFilesTask.kt
@@ -1,31 +1,13 @@
 package com.project.starter.modules.tasks
 
-import com.android.build.gradle.TestedExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 open class ForbidJavaFilesTask : SourceTask() {
-
-    init {
-        if (project.hasProperty("android")) {
-            val extension = project.extensions.getByType(TestedExtension::class.java)
-            extension.sourceSets.configureEach {
-                source += it.java.sourceFiles
-            }
-        } else {
-            val plugin = project.convention.getPlugin(JavaPluginConvention::class.java)
-            plugin.sourceSets.configureEach {
-                if (it.name == "main" || it.name == "test") {
-                    source += it.java
-                }
-            }
-        }
-    }
 
     @TaskAction
     fun run() {


### PR DESCRIPTION
Thanks @wzieba for reporting that